### PR TITLE
Added 1.16 support for PacketInterceptor

### DIFF
--- a/packet-interceptor/src/main/java/com/bringholm/packetinterceptor/v1_0/PacketInterceptor.java
+++ b/packet-interceptor/src/main/java/com/bringholm/packetinterceptor/v1_0/PacketInterceptor.java
@@ -39,7 +39,7 @@ public abstract class PacketInterceptor implements Listener {
     private static final Field NETWORK_MANAGER = ReflectUtil.getFieldByType(ReflectUtil.getNMSClass("PlayerConnection").getOrThrow(), NETWORK_MANAGER_CLASS, 0).getOrThrow();
     private static final Field CHANNEL = ReflectUtil.getFieldByType(NETWORK_MANAGER_CLASS, Channel.class, 0).getOrThrow();
 
-    private static final Method GET_MINECRAFT_SERVER = ReflectUtil.getMethodByType(ReflectUtil.getCBClass("CraftServer").getOrThrow(), ReflectUtil.getNMSClass("MinecraftServer").getOrThrow(), 0).getOrThrow();
+    private static final Method GET_MINECRAFT_SERVER = ReflectUtil.getMethodByType(ReflectUtil.getCBClass("CraftServer").getOrThrow(), ReflectUtil.getNMSClass("DedicatedServer").getOrThrow(), 0).getOrThrow();
     private static final Class<?> SERVER_CONNECTION_CLASS = ReflectUtil.getNMSClass("ServerConnection").getOrThrow();
     private static final Field SERVER_CONNECTION = ReflectUtil.getDeclaredFieldByType(ReflectUtil.getNMSClass("MinecraftServer").getOrThrow(), SERVER_CONNECTION_CLASS, 0, true).getOrThrow();
     private static final Class<?> PACKET_LOGIN_START = ReflectUtil.getNMSClass("PacketLoginInStart").getOrThrow();

--- a/reflect-util/pom.xml
+++ b/reflect-util/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.12.1-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>


### PR DESCRIPTION
Getting the server from a CraftServer no longer returned a MinecraftServer and returned a DedicatedServer. I updated the PacketInterceptor class to reflect this change (A really minor change).